### PR TITLE
Fix images width and tags line wrap.

### DIFF
--- a/app/ui/app/marketplace/marketplace.scss
+++ b/app/ui/app/marketplace/marketplace.scss
@@ -138,6 +138,7 @@
 .marketplace .service-card img {
   float: left;
   margin-right: 15px;
+  max-width: 100%;
 }
 
 .service .placeholder, .marketplace .service-card .placeholder {
@@ -520,6 +521,9 @@
       float: left;
       width: 64px;
       text-align: center;
+      img {
+        max-width: 100%;
+      }
     }
 
     .placeholder > span {

--- a/app/ui/app/marketplace/marketplace.scss
+++ b/app/ui/app/marketplace/marketplace.scss
@@ -68,6 +68,18 @@
     display: flex;
     flex-direction: column;
 
+    .tags {
+      padding-top: 15px;
+      clear: left;
+      font-size: 12px;
+      max-width: 100%;
+      display: flex;
+      flex-wrap: wrap;
+      span {
+        margin: 3px;
+      }
+    }
+
     .card {
       width: 100%;
       height: 100%;


### PR DESCRIPTION
- Fix the issue with images width on both Instances & Marketplace views.
- Make services tags on the Marketplace view wrap into a new line.

**NOTE**: I was not able to run it locally due to the project's dependencies. Changes were tested on Chrome Dev Tools and added to the corresponding `SCSS` files.
